### PR TITLE
Adds documentation for <Slot> component to frontity.md

### DIFF
--- a/docs/api-reference-1/frontity.md
+++ b/docs/api-reference-1/frontity.md
@@ -672,10 +672,10 @@ or
 
 | Name             | Type      | Default     | Required | Description                                                                                                                                                           |
 | :--------------- | :-------- | :---------- | :------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`           | string    | `undefined` | true     | The name of the Slot. The user of this Slot will have to specify this name in order to insert a Fill component.                                                       |
-| `children`       | ReactNode | `undefined` | true     | The component that will be used as a fallback in case that no fill is specified for a particular Slot. You can use any type of data that is valid as a react element. |
-| `data`           | any       | `undefined` | false    | Any data that you might want to pass to the Fill. Normally used for passing route data fetched in the parent component.                                               |
-| `any other prop` | any       | undefined   | false    | Any other custom prop. The theme can specify other props and they will be passed down to the Fill.                                                                    |
+| `name`           | string    | `undefined` | yes     | The name of the Slot. The user of this Slot will have to specify this name in order to insert a Fill component.                                                       |
+| `children`       | ReactNode | `undefined` | yes     | The component that will be used as a fallback in case that no fill is specified for a particular Slot. You can use any type of data that is valid as a react element. |
+| `data`           | any       | `undefined` | no    | Any data that you might want to pass to the Fill. Normally used for passing route data fetched in the parent component.                                               |
+| `any other prop` | any       | undefined   | no    | Any other custom prop. The theme can specify other props and they will be passed down to the Fill.                                                                    |
 
 #### Examples
 

--- a/docs/api-reference-1/frontity.md
+++ b/docs/api-reference-1/frontity.md
@@ -843,14 +843,14 @@ The actual components that will be hooked onto a `<Slot>` should be exposed in `
 ```tsx
 // my-frontity-app/packages/my-theme/src/fills.js
 
-export const FillComponent = ({ 
-  // If the Slot creator has passed a `data` prop to the Slot, 
+export const FillComponent = ({
+  // If the Slot creator has passed a `data` prop to the Slot,
   // you can access it here. Otherwise, this prop will be automatically
   // populated with the value of `state.source.get(state.router.link)`
   data,
 
   // Any other props passed by the creator of the Slot will be available as well!
-  ...props 
+  ...props
   }) => (
     <div>
       This is the fill content
@@ -874,7 +874,7 @@ export default {
   libraries: {
     fills: {
       libNamespace: {
-        ComponentName: FillComponent
+        ComponentName: MyFillComponent
       },
     },
   },

--- a/docs/api-reference-1/frontity.md
+++ b/docs/api-reference-1/frontity.md
@@ -18,11 +18,14 @@ If you are familiar with React hooks, you can use also **`useConnect`** to do th
 
 Use the **`Head`** component whenever you want to add HTML tags inside the `<head>` of any of your site's pages. You can read more **Head** in the [Head page](../learning-frontity/head.md) of our **Learning Frontity** section.
 
+Use the **`Slot`** component whenever you want to add a 'placeholder' to your theme which will be filled with a **`Fill`**. Fills are added to the state in the `state.fills` namespace.
+
 #### **API reference:**
 
 * [connect](frontity.md#connect)
 * [useConnect](frontity.md#useConnect)
 * [Head](frontity.md#head)
+* [Slot](frontity.md#slot)
 
 ### CSS in JS
 

--- a/docs/api-reference-1/frontity.md
+++ b/docs/api-reference-1/frontity.md
@@ -674,8 +674,8 @@ An example might be as follows - the site developer wants to place a third party
 //...
 const Content = () => {
   //...
-  <Slot name="Before Content">
   <Container>
+  <Slot name="Before Content">
   //...
   </Container>
   //...
@@ -788,7 +788,8 @@ const Post = () => (
 
 #### Fills
 
-Fills are added to the `state`, to a common namespace called `fills`. Each fill consists of a configuration object that should be given a unique key and assigned to a namespace. To learn more about namespaces see [this secion](../learning-frontity/namespaces) of our docs.
+Fills are added to the `state`, to a common namespace called `fills`.
+Each fill consists of a configuration object that should be given a unique key and assigned to a namespace. To learn more about namespaces see [this secion](../learning-frontity/namespaces) of our docs.
 
 More than one Fill can be hooked onto any single Slot, and these can be ordered according to a `priority` attribute assigned to the Fill.
 

--- a/docs/api-reference-1/frontity.md
+++ b/docs/api-reference-1/frontity.md
@@ -653,11 +653,36 @@ console.log(decodedText); // "milk and cookies"
 
 ### `Slot`
 
-The `<Slot />` component enables the use of a powerful pattern called Slot and Fill. This allows for  any React component to be inserted into, or hooked onto, different places within the app, thereby improving extensibility.
+The `<Slot />` component enables the use of a powerful pattern called Slot and Fill.
+This allows for  any React component to be inserted into, or hooked onto, different places within the app, thereby improving extensibility.
 
-This component allows a theme developer to insert named `<Slot>` components in various places in a theme. Other package developers are then able to add `<Fill>` components which will be hooked onto the named slots.
+This component allows a theme developer to insert named `<Slot>` components in various places in a theme.
+Other package developers are then able to add *'fill'* components which will be hooked onto the named slots.
 
-More than one Fill can be hooked onto any single Slot, and these can be ordered according to a `priority` attribute assigned to the Fill.
+#### Rationale
+
+When developing a site the developer is often required to make certain customisations to the structure and/or appearance of the site.
+This can be difficult to do and necessitates modifying the core code of the theme.
+
+Theme developers are able to facilitate such customisations by adding `<Slot />` components at various places in the theme, e.g. above the header, below the header, before the content, etc...
+
+These 'slots' can then be filled with custom components that have been added by the site developer and which are then 'hooked' onto a particular 'slot' to insert the content in that place on the page.
+
+An example might be as follows - the site developer wants to place a third party ad above the content of each page. The theme developer has thoughtfully provided a slot in that position in the theme:
+
+```tsx
+//...
+const Content = () => {
+  //...
+  <Slot name="Before Content">
+  <Container>
+  //...
+  </Container>
+  //...
+}
+```
+
+The site developer is now able to 'hook' a component that returns an ad onto that slot, so that the ad gets rendered in that position on the page. This component is referred to as a *'fill'*.
 
 #### Syntax
 
@@ -764,6 +789,8 @@ const Post = () => (
 #### Fills
 
 Fills are added to the `state`, to a common namespace called `fills`. Each fill consists of a configuration object that should be given a unique key and assigned to a namespace. To learn more about namespaces see [this secion](../learning-frontity/namespaces) of our docs.
+
+More than one Fill can be hooked onto any single Slot, and these can be ordered according to a `priority` attribute assigned to the Fill.
 
 ```tsx
 const state = {


### PR DESCRIPTION
Draft of the documentation for the <Slot> component. @juanmaguitar please test to see if you can implement an example based just on this documentation, and highlight where additional clarity might be needed.