### PR TITLE
Updates to root level README.md - 'Welcome to Frontity' page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,29 +4,56 @@
 
 Let's kick things off by providing you with a roadmap so that you can find your way around the documentation and zero in on the information you need right now.
 
+## **About Frontity**
+
+To learn about what Frontity is, how it works, and what features it has, visit the
+[**About Frontity**](about/) section.
+
+If you're a **developer** this section will tell you all about what Frontity is capable of and what you can do with it.
+
+If you're a **project manager** or other **decision maker** that needs to choose or justify whether to use Frontity for your project then this section provides the information you need.
+
 ## **Getting Started**
 
 If you're new to Frontity then you can get started by heading over to, erm..., the [**Getting Started**](getting-started/) section.
 
-This is where you'll find our [**Quick Start Guide**](getting-started/quick-start-guide.md) that will get you up and running with Frontity quickly. In particular we would like to draw your attention to the [**Initial checks**](https://docs.frontity.org/getting-started#initial-checks) section.
+This is where you'll find our [**Quick Start Guide**](getting-started/quick-start-guide.md) that will get you up and running with Frontity quickly. In particular we would like to draw your attention to the [**Initial checks**](https://docs.frontity.org/getting-started#initial-checks) section. Make sure you read this <ins>before</ins> running the installer.
 
 Once you've followed the Quick Start Guide and have a working Frontity installation we'll show you how to [**connect Frontity up to your own WordPress site**](getting-started/connecting-to-wordpress.md) and also how to customise the menu to reflect the structure of your WordPress site.
 
-## **Learning Frontity**
+## **CLI Commands**
 
-This section is the heart of our documentation. Once you've nailed the basics in the Getting Started section you should head over to the [**Learning Frontity**](learning-frontity/) section to really dig in to the detail and learn how to work with Frontity.
+If you've followed our [Getting Started] section then you've already used the Frontity CLI to create your first Frontity project. This section is a reference guide to all the other CLI commands that you can use and that can help you during the life-cycle of your project.
+
+## **Core Concepts**
+
+This section is the heart of our documentation. Once you've nailed the basics in the Getting Started section you should head over to the [**Core Concepts**](learning-frontity/) section to really dig in to the detail and learn how to work with Frontity.
 
 ## **Architecture and Deployment**
 
-Find out about how the relationship between Frontity and WordPress is structured in the [**Architecture**](https://github.com/frontity/docs/tree/1a3f3a66fb661dd5b4c485006d09a9ea5caf7598/docs/architecture/README.md) section and, once you have a working application that you're happy with, how to deploy to live in the [**Deployment**](deployment/) section.
+Find out about how the relationship between Frontity and WordPress is structured in the [**Architecture**](architecture/) section. This section will also tell you more about possible hosting solutions.
 
-## **Packages and Themes**
+## **Deployment**
 
-In reality a Frontity theme is just a special instance of a Frontity package. Really **everything** is a package when you're working with Frontity.
+Once you've completed the development of your project and have a working application that you're happy with you can learn how to deploy to live in the [**Deployment**](deployment/) section.
 
-Frontity comes with a number of useful packages for routing, API source, and so on. You can learn all about each of them in the section entitled [**Frontity Packages**](api-reference-1/).
+In particular we go into detail on how to [**deploy to Vercel**](deployment/deploy-using-vercel/), our recommended hosting platform. Why do we recommend it? Because it's serverless, cheap, includes a CDN, and is really easy to set up.
 
-The included themes, namely Mars and TwentyTwenty, are dealt with separately from the other packages under the [**Frontity Themes**](frontity-themes/) section.
+## **Packages**
+
+Frontity comes with a number of useful packages for routing, API source, and so on. You can learn all about each of them in the section entitled [**Packages**](api-reference-1/).
+
+## **Themes**
+
+Really **everything** is a package when you're working with Frontity.
+
+However a Frontity theme is a special instance of a Frontity package. The included themes, namely Mars and TwentyTwenty, are therefore dealt with separately from the other packages under the [**Themes**](frontity-themes/) section.
+
+## **WordPress Plugins**
+
+The team at Frontity are working on some WordPress plugins that you can install and activate in your WordPress installation. These will help you make the most of headless/decoupled WordPress by adding some useful functionality to the backend.
+
+Learn about the growing list of plugins that can help both enhance your site and make your development easier in the [**WordPress Plugins**](frontity-plugins/) section.
 
 ## **Guides**
 
@@ -34,21 +61,20 @@ This is where you'll find an ever-growing series of [**Guides**](guides/). Some 
 
 This is where you can really have fun with Frontity and work toward your stretch goals.
 
+In this section we also provide you with some foundational knowledge that will assist you when working with Frontity. So if you need a refresher, or if you're new to the topics, we have included introductions to JavaScript/ES6 and React in this section.
+
+Our troubleshooting guide is also here, for when you encounter problems. If your problem is not solved here then don't forget that you can also ask it in our [**Community Forum**](https://community.frontity.org).
+
+
 ## **Contributing**
 
 Frontity is an open source project and we welcome contributions from the community. The [**Contributing**](contributing/) section of the documentation will guide you whether you want to make a single contribution or whether you intend to become a fully fledged contributor to the Frontity project.
 
 We can't wait to see where you take Frontity in the future.
 
-## **And that's not all**
 
-There's yet more to the Frontity documentation.
+___
 
-[**Frontity's WordPress Plugins**](frontity-plugins/) are plugins built by the team here at Frontity that you install and activate in your WordPress site and that will enhance your Frontity site.
-
-[**Key Concepts**](resources/) will help you with some foundational knowledge that will assist you when working with Frontity. Here we even provide you with introductions to JavaScript/ES6 and React, just in case you need them.
-
-[**FAQ**](faq.md) Frequently Asked Questions - but you already knew that, didn't you?! 😀
 
 By the way, we'd love to hear about what you're building with Frontity. Join us in our [**Community Forum**](https://community.frontity.org) and tell us about your project. You can also ask questions and get help and support from our growing community of users and developers there.
 

--- a/docs/getting-started/next-steps.md
+++ b/docs/getting-started/next-steps.md
@@ -10,7 +10,7 @@ With Frontity you won't have your site code in the root folder as you would with
 
 If you're just starting out with Frontity then the theme you should have selected when you ran `npx frontity create` will be `@frontity/mars-theme`. You can find it in `packages/mars-theme/`. Go ahead and edit any of its files while running Frontity and the site will refresh automatically.
 
-Move onto the [**Learning Frontity**](../learning-frontity/) section to dig in to the details of Frontity and how you can work with it.
+Move onto the [**Core Concepts**](../learning-frontity/) section to dig in to the details of Frontity and how you can work with it.
 
 > `npx frontity create` will install the `mars-theme` in `packages/` so the theme can be edited by the developer. However, this theme doesn't need to reside in `packages/` if you don't want to edit it. It can be installed directly with `npm` inside `node_modules/` and it will work exactly the same.
 


### PR DESCRIPTION
Updates to root level `README.md` - 'Welcome to Frontity' page - to reflect new sidebar menu structure. Also changed reference to 'Learning Frontity' to 'Core Concepts' in `getting-started/next-steps.md`.