### PR TITLE
Fix 'analytic' --> 'analytics' in the sidebar menu and package docs

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -33,7 +33,7 @@
 * [⚙ Packages](api-reference-1/README.md)
   * [frontity](api-reference-1/frontity.md)
   
-  * [Analytic packages](api-reference-1/frontity-analytics.md)
+  * [Analytics packages](api-reference-1/frontity-analytics.md)
   * [@frontity/tiny-router](api-reference-1/router.md)
   * [@frontity/wp-source](api-reference-1/wordpress-source.md)
   * [@frontity/components](api-reference-1/frontity-components.md)

--- a/docs/api-reference-1/frontity-analytics.md
+++ b/docs/api-reference-1/frontity-analytics.md
@@ -25,7 +25,7 @@ Each package will require some custom configuration to add things such as tracki
 
 Once we have properly installed and configured these `analytics` packages, their actions will be centralized by the `analytics` namespace.
 
-In `frontity.settings.js` we can enable/disable specific analytic packages for pageviews or events through the following properties in the `state` (under the `analytics` namespace)
+In `frontity.settings.js` we can enable/disable specific analytics packages for pageviews or events through the following properties in the `state` (under the `analytics` namespace)
 
 - `state.analytics.pageviews`
 - `state.analytics.events`


### PR DESCRIPTION
Fix `analytic packages` --> `analytics packages` in the sidebar menu and the analytics package docs.

There are no other changes.