### PR TITLE
Add missing link

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -28,7 +28,7 @@ To get started with Frontity you will need:
 
   You will use these to run Frontity commands during the set-up and development of your project
 
-> For those coming from WordPress it might be worth noting that **Frontity** runs on **Node**, so it needs to be deployed in a different server than your WordPress. If you want to learn more about this, visit our [GitHub repo](https://github.com/frontity/frontity#why-a-different-nodejs-server) or see the [Architecture](./) section arch these docs.
+> For those coming from WordPress it might be worth noting that **Frontity** runs on **Node**, so it needs to be deployed in a different server than your WordPress. If you want to learn more about this, visit our [GitHub repo](https://github.com/frontity/frontity#why-a-different-nodejs-server) or see the [Architecture](../architecture.md) section arch these docs.
 
 ## Initial checks
 


### PR DESCRIPTION
Add missing link to Architecture section on Getting started page