### PR TITLE
Fix `state.source.get` arguments description

### DIFF
--- a/docs/api-reference-1/wordpress-source.md
+++ b/docs/api-reference-1/wordpress-source.md
@@ -4,36 +4,36 @@ This package is in charge of getting the data from self-hosted WordPress or Word
 
 ## Table of contents
 
-* [Installation](wordpress-source.md#installation)
-* [Settings](wordpress-source.md#settings)
-  * [`state.source.api`](wordpress-source.md#state-source-api)
-  * [`state.source.subdirectory`](wordpress-source.md#state-source-subdirectory)
-  * [`state.source.homepage`](wordpress-source.md#state-source-homepage)
-  * [`state.source.postsPage`](wordpress-source.md#state-source-postspage)
-  * [`state.source.categoryBase`](wordpress-source.md#state-source-categorybase)
-  * [`state.source.tagBase`](wordpress-source.md#state-source-tagbase)
-  * [`state.source.postEndpoint`](wordpress-source.md#state-source-postendpoint)
-  * [`state.source.params`](wordpress-source.md#state-source-params)
-  * [`state.source.postTypes`](wordpress-source.md#state-source-posttypes)
-  * [`state.source.taxonomies`](wordpress-source.md#state-source-taxonomies)
-* [How to use](wordpress-source.md#how-to-use)
-* [API Reference](wordpress-source.md#api-reference)
-  * [Actions](wordpress-source.md#actions)
-    * [`actions.source.fetch()`](wordpress-source.md#actions-source-fetch)
-  * [State](wordpress-source.md#state)
-    * [`state.source.get()`](wordpress-source.md#state-source-get)
-    * [`state.source[taxonomy][id]`](wordpress-source.md#state-source-taxonomy-id)
-    * [`state.source[type][id]`](wordpress-source.md#state-source-type-id)
-    * [`state.source.author[id]`](wordpress-source.md#state-source-author-id)
-  * [Libraries](wordpress-source.md#libraries)
-    * [`libraries.source.api.init()`](wordpress-source.md#libraries-source-api-init)
-    * [`libraries.source.api.get()`](wordpress-source.md#libraries-source-api-get)
-    * [`libraries.source.populate()`](wordpress-source.md#libraries-source-populate)
-    * [`libraries.source.handlers`](wordpress-source.md#libraries-source-handlers)
-    * [`libraries.source.redirections`](wordpress-source.md#libraries-source-redirections)
-    * [`libraries.source.parse()`](wordpress-source.md#libraries-source-parse)
-    * [`libraries.source.stringify()`](wordpress-source.md#libraries-source-stringify)
-    * [`libraries.source.normalize()`](wordpress-source.md#libraries-source-normalize)
+- [Installation](wordpress-source.md#installation)
+- [Settings](wordpress-source.md#settings)
+  - [`state.source.api`](wordpress-source.md#state-source-api)
+  - [`state.source.subdirectory`](wordpress-source.md#state-source-subdirectory)
+  - [`state.source.homepage`](wordpress-source.md#state-source-homepage)
+  - [`state.source.postsPage`](wordpress-source.md#state-source-postspage)
+  - [`state.source.categoryBase`](wordpress-source.md#state-source-categorybase)
+  - [`state.source.tagBase`](wordpress-source.md#state-source-tagbase)
+  - [`state.source.postEndpoint`](wordpress-source.md#state-source-postendpoint)
+  - [`state.source.params`](wordpress-source.md#state-source-params)
+  - [`state.source.postTypes`](wordpress-source.md#state-source-posttypes)
+  - [`state.source.taxonomies`](wordpress-source.md#state-source-taxonomies)
+- [How to use](wordpress-source.md#how-to-use)
+- [API Reference](wordpress-source.md#api-reference)
+  - [Actions](wordpress-source.md#actions)
+    - [`actions.source.fetch()`](wordpress-source.md#actions-source-fetch)
+  - [State](wordpress-source.md#state)
+    - [`state.source.get()`](wordpress-source.md#state-source-get)
+    - [`state.source[taxonomy][id]`](wordpress-source.md#state-source-taxonomy-id)
+    - [`state.source[type][id]`](wordpress-source.md#state-source-type-id)
+    - [`state.source.author[id]`](wordpress-source.md#state-source-author-id)
+  - [Libraries](wordpress-source.md#libraries)
+    - [`libraries.source.api.init()`](wordpress-source.md#libraries-source-api-init)
+    - [`libraries.source.api.get()`](wordpress-source.md#libraries-source-api-get)
+    - [`libraries.source.populate()`](wordpress-source.md#libraries-source-populate)
+    - [`libraries.source.handlers`](wordpress-source.md#libraries-source-handlers)
+    - [`libraries.source.redirections`](wordpress-source.md#libraries-source-redirections)
+    - [`libraries.source.parse()`](wordpress-source.md#libraries-source-parse)
+    - [`libraries.source.stringify()`](wordpress-source.md#libraries-source-stringify)
+    - [`libraries.source.normalize()`](wordpress-source.md#libraries-source-normalize)
 
 ## Installation
 
@@ -147,9 +147,9 @@ and then you visit a URL \(or use `actions.source.fetch`\), the query part of th
 
 This option allows you to show the Custom Post Types you create at WordPress when accessing their URLs. It is an array of objects, each object being a different CPT. It has three arguments:
 
-* `type` : Type slug. The slug you configured for your Custom Post Type. e.g. `movies`
-* `endpoint` : REST API endpoint from where this post type can be fetched. e.g. `movies`
-* `archive` \(optional\): the URL of the archive of this Custom Post Type, where all of them are listed. e.g. `/movies_archive` .
+- `type` : Type slug. The slug you configured for your Custom Post Type. e.g. `movies`
+- `endpoint` : REST API endpoint from where this post type can be fetched. e.g. `movies`
+- `archive` \(optional\): the URL of the archive of this Custom Post Type, where all of them are listed. e.g. `/movies_archive` .
 
 Differentiating `type` and `endpoint` may be confusing as they are usually the same. You can confirm you are doing it correctly going to the CPT `endpoint` :
 
@@ -171,10 +171,10 @@ postTypes: [
 
 Similar to `postTypes`setting, this one allows you to show the lists of posts of a Custom Taxonomies you create at WordPress when accessing their URLs. It is an array of objects, each object being a different Custom Taxonomy. It has four arguments:
 
-* `taxonomy` : Taxonomy slug. The slug you configured for your Custom Taxonomy.
-* `endpoint` : REST API endpoint from which this taxonomy can be fetched.
-* `postTypeEndpoint` \(optional\): REST API endpoint from which posts of this taxonomy can be fetched. Defaults to "posts", but **please note** that if the Custom Taxonomy is meant to load Custom Post Types instead, you have to add its endpoint here. To clarify, although optional for posts in the case of a Custom Post Type this argument is **required**.
-* `params` \(optional\): Extra params to be used while fetching the list of posts.
+- `taxonomy` : Taxonomy slug. The slug you configured for your Custom Taxonomy.
+- `endpoint` : REST API endpoint from which this taxonomy can be fetched.
+- `postTypeEndpoint` \(optional\): REST API endpoint from which posts of this taxonomy can be fetched. Defaults to "posts", but **please note** that if the Custom Taxonomy is meant to load Custom Post Types instead, you have to add its endpoint here. To clarify, although optional for posts in the case of a Custom Post Type this argument is **required**.
+- `params` \(optional\): Extra params to be used while fetching the list of posts.
 
 Again, differentiating `taxonomy` and `endpoint`may be confusing as they usually are the same too. You can confirm you are doing it correctly by going to the Custom Taxonomy `endpoint` :
 
@@ -253,9 +253,9 @@ export default connect(CategoryNature);
 {% hint style="info" %}
 If you want to know more about how to use the `wp-source` package, here you have some videos where Frontity DevRel team talks about it:
 
-* 📺 [Frontity Talks 2020-01 - wp-source & CSS In JS \[1:36\]](https://www.youtube.com/watch?v=e-_66W8pfdY&t=96s)
-* 📺 [Frontity Talks 2020-02 - Pagination example & wp-source \(state & fetch\) \[17:53\]](https://www.youtube.com/watch?v=eW5xZlpcqQk&t=1073s)
-{% endhint %}
+- 📺 [Frontity Talks 2020-01 - wp-source & CSS In JS \[1:36\]](https://www.youtube.com/watch?v=e-_66W8pfdY&t=96s)
+- 📺 [Frontity Talks 2020-02 - Pagination example & wp-source \(state & fetch\) \[17:53\]](https://www.youtube.com/watch?v=eW5xZlpcqQk&t=1073s)
+  {% endhint %}
 
 ## API Reference
 
@@ -276,13 +276,13 @@ This action fetches all entities related to a `link`, i.e. the pathname of a URL
 {% hint style="info" %}
 `(link: string, options: object) => Promise`
 
-* **Parameters**
-  * **`link`**: string\` Link representing a REST API endpoint or custom handler
-  * _`options`_: `object` _\(optional\)_
-    * _`force`_: `boolean` The entities should be fetched again.
-* **Return value**
-  * `Promise` it doesn't return data but a promise that is resolved when the action is finished \(and state is updated\)
-{% endhint %}
+- **Parameters**
+  - **`link`**: string\` Link representing a REST API endpoint or custom handler
+  - _`options`_: `object` _\(optional\)_
+    - _`force`_: `boolean` The entities should be fetched again.
+- **Return value**
+  - `Promise` it doesn't return data but a promise that is resolved when the action is finished \(and state is updated\)
+    {% endhint %}
 
 All received data are populated in `state.source` and are accessible using the methods explained in the next section.
 
@@ -307,8 +307,8 @@ const somePost = state.source.get("/some-post"); // <- The data will exist.
 
 In React components, you won't need to use `async/await` with `fetch` because:
 
-* [`useEffect` doesn't directly accept `async` functions](https://reactjs.org/docs/hooks-reference.html#useeffect) although [it can contain `async`](https://www.robinwieruch.de/react-hooks-fetch-data) functions
-* They re-render when the `state` accessed changes.
+- [`useEffect` doesn't directly accept `async` functions](https://reactjs.org/docs/hooks-reference.html#useeffect) although [it can contain `async`](https://www.robinwieruch.de/react-hooks-fetch-data) functions
+- They re-render when the `state` accessed changes.
 
 ```javascript
 const SomePost = ({ actions, state }) => {
@@ -341,11 +341,11 @@ Returns an object that gives you info about the type of that link and related en
 {% hint style="info" %}
 `(link: string) => object`
 
-* **Parameters**
-  * **`link`**: `string` Link representing a REST API endpoint or custom handler
-* **Return value**
-  * `object` Info about the type of data represented in the URL
-{% endhint %}
+- **Parameters**
+  - **`link`**: `string` Link that points to a page in the Frontity site.
+- **Return value**
+  - `object` Info about the type of data represented in the link.
+    {% endhint %}
 
 For example:
 
@@ -391,22 +391,22 @@ will return something like
 
 The information to distinguish each type of link is based on the [WP Template Hierarchy](https://wphierarchy.com/) and is as follows:
 
-* archives: `isArchive`
-  * taxonomy: `isTaxonomy`
-    * category: `isCategory`
-    * tag: `isTag`
-    * deal: `isDeal`
-  * author: `isAuthor`
-  * postTypeArchive: `isPostTypeArchive`
-    * post: `isHome`, `isPostArchive` \(`isFrontPage` optional\)
-    * product: `isProductArchive`
-  * date: `isDate`
-* postTypes: `isPostType`
-  * post: `isPost`
-  * page: `isPage` \(`isFrontPage` optional\)
-  * product: `isProduct`
-  * media: `isMedia`, `isAttachment`
-* 404: `is404`
+- archives: `isArchive`
+  - taxonomy: `isTaxonomy`
+    - category: `isCategory`
+    - tag: `isTag`
+    - deal: `isDeal`
+  - author: `isAuthor`
+  - postTypeArchive: `isPostTypeArchive`
+    - post: `isHome`, `isPostArchive` \(`isFrontPage` optional\)
+    - product: `isProductArchive`
+  - date: `isDate`
+- postTypes: `isPostType`
+  - post: `isPost`
+  - page: `isPage` \(`isFrontPage` optional\)
+  - product: `isProduct`
+  - media: `isMedia`, `isAttachment`
+- 404: `is404`
 
 Additionally, if calling `get()` has returned a status code higher than `400`, we add information about the error to the state. For example, if an error code was `500`, the state will include the following properties:
 
@@ -425,11 +425,11 @@ Additionally, if calling `get()` has returned a status code higher than `400`, w
 
 Properties added to each type are also based on the [WP REST API](https://developer.wordpress.org/rest-api/reference/):
 
-* taxonomy: `taxonomy`, `id`
-* author: `id`
-* postTypeArchive: `type`
-* date: `year`, `month`, `date`
-* postType: `type`, `id`
+- taxonomy: `taxonomy`, `id`
+- author: `id`
+- postTypeArchive: `type`
+- date: `year`, `month`, `date`
+- postType: `type`, `id`
 
 #### `state.source[taxonomy][id]`
 
@@ -472,11 +472,11 @@ Set the URL to the WordPress REST API.
 {% hint style="info" %}
 `(link: string, options: object) => Promise`
 
-* **Parameters**
-  * `options: object`
-    * **`api`**: `string` URL pointing to a valid WP REST API.
-    * **`isWpCom`**: `boolean` if the WP REST route is from a WordPress.com hosted site.
-{% endhint %}
+- **Parameters**
+  - `options: object`
+    _ **`api`**: `string` URL pointing to a valid WP REST API.
+    _ **`isWpCom`**: `boolean` if the WP REST route is from a WordPress.com hosted site.
+    {% endhint %}
 
 **Example**
 
@@ -503,15 +503,15 @@ Request entity from the WordPress REST API.
 {% hint style="info" %}
 `(options: object) => Promise`
 
-* **Parameters**
-  * `options: object`
-    * **`endpoint`**: `string` Name of the endpoint if is a `/wp/v2` endpoint \(e.g. `posts`\), or the full path of other REST endpoints \(e.g. `/acf/v3/posts`\).
-    * **`params`**: `string` Any parameter that will be included in the query params.
-    * _`api`_: `string` _\(optional\)_ Overrides the value set with `api.set.`
-    * _`isWpCom`_: `boolean` _\(optional\)_ Overrides the value set with `api.set.`
-* **Return value**
-  * `Promise` Promise resolving to a [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) object from the fetch.
-{% endhint %}
+- **Parameters**
+  - `options: object`
+    - **`endpoint`**: `string` Name of the endpoint if is a `/wp/v2` endpoint \(e.g. `posts`\), or the full path of other REST endpoints \(e.g. `/acf/v3/posts`\).
+    - **`params`**: `string` Any parameter that will be included in the query params.
+    - _`api`_: `string` _\(optional\)_ Overrides the value set with `api.set.`
+    - _`isWpCom`_: `boolean` _\(optional\)_ Overrides the value set with `api.set.`
+- **Return value**
+  - `Promise` Promise resolving to a [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) object from the fetch.
+    {% endhint %}
 
 For more info, visit the [WP REST API reference](https://developer.wordpress.org/rest-api/reference).
 
@@ -546,27 +546,27 @@ Add entities to the Frontity state.
 {% hint style="info" %}
 `(options: object) => Promise`
 
-* **Parameters**
-  * `options: object`
-    * **`response`**: `object` The response object returned by `api.get().`
-    * **`state`**: `object` The state object from the Frontity store.
-    * _`subdirectory`_: `string` _\(optional\)_ Domain's subdirectory where your Frontity site is accessible. When this options is passed, this subdirectory is added to the entities' links. By default, it takes the value defined in `state.source.subdirectory`.
-    * _`force`_: `boolean` _\(optional\)_ Value indicating if the entities should be overwritten.`false` by default.
-* **Return value**
-  * `Array` An array of objects with attributes `type`, `id` and `link` representing the added entities.
-{% endhint %}
+- **Parameters**
+  - `options: object`
+    - **`response`**: `object` The response object returned by `api.get().`
+    - **`state`**: `object` The state object from the Frontity store.
+    - _`subdirectory`_: `string` _\(optional\)_ Domain's subdirectory where your Frontity site is accessible. When this options is passed, this subdirectory is added to the entities' links. By default, it takes the value defined in `state.source.subdirectory`.
+    - _`force`_: `boolean` _\(optional\)_ Value indicating if the entities should be overwritten.`false` by default.
+- **Return value**
+  - `Array` An array of objects with attributes `type`, `id` and `link` representing the added entities.
+    {% endhint %}
 
 Entities are normally never overwritten. So, if an entity already exists in the state and a new one is fetched, the one in the state will prevail. If you want to overwrite them, `populate` should be called with `force: true`.
 
 **Example**
 
 ```javascript
-const response = await libraries.source.api.get({ endpoint: "posts" })
-const entitiesAdded = await libraries.source.populate({ response, state })
+const response = await libraries.source.api.get({ endpoint: "posts" });
+const entitiesAdded = await libraries.source.populate({ response, state });
 
-entitiesAdded.forEach(({type, id, link}) => {
-  console.log({type, id, link})
-})
+entitiesAdded.forEach(({ type, id, link }) => {
+  console.log({ type, id, link });
+});
 ```
 
 #### `libraries.source.handlers`
@@ -576,20 +576,19 @@ Handlers are objects that associate a path pattern with a function that gets the
 {% hint style="info" %}
 A handler is defined by an object with the following properties:
 
-* **`name`**: `string` Identifier of the handler.
-* **`priority`**: `number` Number that lets `fetch` to know in which order handlers should be evaluated.
-* **`pattern`**: `regExp` Pattern which paths are compared with. We use [path-to-regexp](https://github.com/pillarjs/path-to-regexp) under the hood, so check its documentation to know how to write patterns.
-* **`func`**: `function` Asynchronous function that retrieves entities and adds all info to the state.
-  * Arguments
-    * `options: object`
-      * **`link`**: `string` The link that are being fetched.
-      * **`params`**: values obtained from the pattern after a match
-      * **`state`**: `object` Frontity state.
-      * **`libraries`**: `object` Frontity libraries.
-      * **`force`**: `boolean` If the entities should be fetched again. Internally, this parameter will be passed to the `actions.source.fetch` call.
-  * Return value
-    * `Promise` Promise resolving to custom data
-{% endhint %}
+- **`name`**: `string` Identifier of the handler.
+- **`priority`**: `number` Number that lets `fetch` to know in which order handlers should be evaluated.
+- **`pattern`**: `regExp` Pattern which paths are compared with. We use [path-to-regexp](https://github.com/pillarjs/path-to-regexp) under the hood, so check its documentation to know how to write patterns.
+- **`func`**: `function` Asynchronous function that retrieves entities and adds all info to the state.
+  - Arguments
+    - `options: object`
+      - **`link`**: `string` The link that are being fetched.
+      - **`params`**: values obtained from the pattern after a match
+      - **`state`**: `object` Frontity state.
+      - **`libraries`**: `object` Frontity libraries.
+      - **`force`**: `boolean` If the entities should be fetched again. Internally, this parameter will be passed to the `actions.source.fetch` call.
+  - Return value \* `Promise` Promise resolving to custom data
+    {% endhint %}
 
 `libraries.source.handlers` is an array., so **to add new handlers we can use `libraries.source.handlers.push()`**
 
@@ -633,16 +632,16 @@ Redirections are objects that associate a path pattern with a function that retu
 {% hint style="info" %}
 A redirection is defined by an object with the following properties:
 
-* **`name`**: `string` Identifier of the redirection.
-* **`priority`**: `number` Let `fetch` to know in which order redirections should be evaluated.
-* **`pattern`**: `regExp` Pattern which paths are compared with.
-* **`func`**: Function that returns a new path. It receives an object with the params obtained after a match.
-  * Arguments
-    * `options: object`
-      * **`slug`**: `string` The link that is being fetched.
-    * Return value
-      * `string` a new path
-{% endhint %}
+- **`name`**: `string` Identifier of the redirection.
+- **`priority`**: `number` Let `fetch` to know in which order redirections should be evaluated.
+- **`pattern`**: `regExp` Pattern which paths are compared with.
+- **`func`**: Function that returns a new path. It receives an object with the params obtained after a match.
+  - Arguments
+    _ `options: object`
+    _ **`slug`**: `string` The link that is being fetched.
+    _ Return value
+    _ `string` a new path
+    {% endhint %}
 
 **Example**
 
@@ -663,15 +662,15 @@ Utility for parsing links.
 {% hint style="info" %}
 `(link: string) => object`
 
-* **Parameters**
-  * `link`: any link that points to entities in your site \(links, custom lists, etc.\)
-* **Return value**
-  * `object`
-    * **`path`**: `string` Pathname without the page
-    * **`page`**: `number` The page number
-    * **`query`**: `object` Object with query parameters
-    * **`hash`**: `string` The hash value \(with `#`\).
-{% endhint %}
+- **Parameters**
+  - `link`: any link that points to entities in your site \(links, custom lists, etc.\)
+- **Return value**
+  - `object`
+    _ **`path`**: `string` Pathname without the page
+    _ **`page`**: `number` The page number
+    _ **`query`**: `object` Object with query parameters
+    _ **`hash`**: `string` The hash value \(with `#`\).
+    {% endhint %}
 
 #### `libraries.source.stringify()`
 
@@ -680,27 +679,26 @@ Utility for building links from its attributes.
 {% hint style="info" %}
 `(args: object) => string`
 
-* **Parameters**
-  * **`path`**: `string` pathname without the page
-  * _`page`_: `number` _\(optional\)_ The page number
-  * _`query`_: `object` _\(optional\)_ Object with query parameters
-  * _`hash`_: `string` _\(optional\)_ The hash value \(with `#`\).
-* **Return value**
-  * `link`: `string` Normalized link
-{% endhint %}
+- **Parameters**
+  - **`path`**: `string` pathname without the page
+  - _`page`_: `number` _\(optional\)_ The page number
+  - _`query`_: `object` _\(optional\)_ Object with query parameters
+  - _`hash`_: `string` _\(optional\)_ The hash value \(with `#`\).
+- **Return value**
+  - `link`: `string` Normalized link
+    {% endhint %}
 
 #### `libraries.source.normalize()`
 
 {% hint style="info" %}
 `(link: string) => string`
 
-* **Parameters**
-  * `link`: `string` Any link that points to entities in your site \(links, custom lists, etc.\)
-* **Return value**
-  * `link`: `string` Normalized link
-{% endhint %}
+- **Parameters**
+  - `link`: `string` Any link that points to entities in your site \(links, custom lists, etc.\)
+- **Return value**
+  - `link`: `string` Normalized link
+    {% endhint %}
 
 {% hint style="info" %}
 Still have questions? Ask [the community](https://community.frontity.org/)! We are here to help 😊
 {% endhint %}
-

--- a/docs/api-reference-1/wordpress-source.md
+++ b/docs/api-reference-1/wordpress-source.md
@@ -4,36 +4,36 @@ This package is in charge of getting the data from self-hosted WordPress or Word
 
 ## Table of contents
 
-- [Installation](wordpress-source.md#installation)
-- [Settings](wordpress-source.md#settings)
-  - [`state.source.api`](wordpress-source.md#state-source-api)
-  - [`state.source.subdirectory`](wordpress-source.md#state-source-subdirectory)
-  - [`state.source.homepage`](wordpress-source.md#state-source-homepage)
-  - [`state.source.postsPage`](wordpress-source.md#state-source-postspage)
-  - [`state.source.categoryBase`](wordpress-source.md#state-source-categorybase)
-  - [`state.source.tagBase`](wordpress-source.md#state-source-tagbase)
-  - [`state.source.postEndpoint`](wordpress-source.md#state-source-postendpoint)
-  - [`state.source.params`](wordpress-source.md#state-source-params)
-  - [`state.source.postTypes`](wordpress-source.md#state-source-posttypes)
-  - [`state.source.taxonomies`](wordpress-source.md#state-source-taxonomies)
-- [How to use](wordpress-source.md#how-to-use)
-- [API Reference](wordpress-source.md#api-reference)
-  - [Actions](wordpress-source.md#actions)
-    - [`actions.source.fetch()`](wordpress-source.md#actions-source-fetch)
-  - [State](wordpress-source.md#state)
-    - [`state.source.get()`](wordpress-source.md#state-source-get)
-    - [`state.source[taxonomy][id]`](wordpress-source.md#state-source-taxonomy-id)
-    - [`state.source[type][id]`](wordpress-source.md#state-source-type-id)
-    - [`state.source.author[id]`](wordpress-source.md#state-source-author-id)
-  - [Libraries](wordpress-source.md#libraries)
-    - [`libraries.source.api.init()`](wordpress-source.md#libraries-source-api-init)
-    - [`libraries.source.api.get()`](wordpress-source.md#libraries-source-api-get)
-    - [`libraries.source.populate()`](wordpress-source.md#libraries-source-populate)
-    - [`libraries.source.handlers`](wordpress-source.md#libraries-source-handlers)
-    - [`libraries.source.redirections`](wordpress-source.md#libraries-source-redirections)
-    - [`libraries.source.parse()`](wordpress-source.md#libraries-source-parse)
-    - [`libraries.source.stringify()`](wordpress-source.md#libraries-source-stringify)
-    - [`libraries.source.normalize()`](wordpress-source.md#libraries-source-normalize)
+* [Installation](wordpress-source.md#installation)
+* [Settings](wordpress-source.md#settings)
+  * [`state.source.api`](wordpress-source.md#state-source-api)
+  * [`state.source.subdirectory`](wordpress-source.md#state-source-subdirectory)
+  * [`state.source.homepage`](wordpress-source.md#state-source-homepage)
+  * [`state.source.postsPage`](wordpress-source.md#state-source-postspage)
+  * [`state.source.categoryBase`](wordpress-source.md#state-source-categorybase)
+  * [`state.source.tagBase`](wordpress-source.md#state-source-tagbase)
+  * [`state.source.postEndpoint`](wordpress-source.md#state-source-postendpoint)
+  * [`state.source.params`](wordpress-source.md#state-source-params)
+  * [`state.source.postTypes`](wordpress-source.md#state-source-posttypes)
+  * [`state.source.taxonomies`](wordpress-source.md#state-source-taxonomies)
+* [How to use](wordpress-source.md#how-to-use)
+* [API Reference](wordpress-source.md#api-reference)
+  * [Actions](wordpress-source.md#actions)
+    * [`actions.source.fetch()`](wordpress-source.md#actions-source-fetch)
+  * [State](wordpress-source.md#state)
+    * [`state.source.get()`](wordpress-source.md#state-source-get)
+    * [`state.source[taxonomy][id]`](wordpress-source.md#state-source-taxonomy-id)
+    * [`state.source[type][id]`](wordpress-source.md#state-source-type-id)
+    * [`state.source.author[id]`](wordpress-source.md#state-source-author-id)
+  * [Libraries](wordpress-source.md#libraries)
+    * [`libraries.source.api.init()`](wordpress-source.md#libraries-source-api-init)
+    * [`libraries.source.api.get()`](wordpress-source.md#libraries-source-api-get)
+    * [`libraries.source.populate()`](wordpress-source.md#libraries-source-populate)
+    * [`libraries.source.handlers`](wordpress-source.md#libraries-source-handlers)
+    * [`libraries.source.redirections`](wordpress-source.md#libraries-source-redirections)
+    * [`libraries.source.parse()`](wordpress-source.md#libraries-source-parse)
+    * [`libraries.source.stringify()`](wordpress-source.md#libraries-source-stringify)
+    * [`libraries.source.normalize()`](wordpress-source.md#libraries-source-normalize)
 
 ## Installation
 
@@ -147,9 +147,9 @@ and then you visit a URL \(or use `actions.source.fetch`\), the query part of th
 
 This option allows you to show the Custom Post Types you create at WordPress when accessing their URLs. It is an array of objects, each object being a different CPT. It has three arguments:
 
-- `type` : Type slug. The slug you configured for your Custom Post Type. e.g. `movies`
-- `endpoint` : REST API endpoint from where this post type can be fetched. e.g. `movies`
-- `archive` \(optional\): the URL of the archive of this Custom Post Type, where all of them are listed. e.g. `/movies_archive` .
+* `type` : Type slug. The slug you configured for your Custom Post Type. e.g. `movies`
+* `endpoint` : REST API endpoint from where this post type can be fetched. e.g. `movies`
+* `archive` \(optional\): the URL of the archive of this Custom Post Type, where all of them are listed. e.g. `/movies_archive` .
 
 Differentiating `type` and `endpoint` may be confusing as they are usually the same. You can confirm you are doing it correctly going to the CPT `endpoint` :
 
@@ -171,10 +171,10 @@ postTypes: [
 
 Similar to `postTypes`setting, this one allows you to show the lists of posts of a Custom Taxonomies you create at WordPress when accessing their URLs. It is an array of objects, each object being a different Custom Taxonomy. It has four arguments:
 
-- `taxonomy` : Taxonomy slug. The slug you configured for your Custom Taxonomy.
-- `endpoint` : REST API endpoint from which this taxonomy can be fetched.
-- `postTypeEndpoint` \(optional\): REST API endpoint from which posts of this taxonomy can be fetched. Defaults to "posts", but **please note** that if the Custom Taxonomy is meant to load Custom Post Types instead, you have to add its endpoint here. To clarify, although optional for posts in the case of a Custom Post Type this argument is **required**.
-- `params` \(optional\): Extra params to be used while fetching the list of posts.
+* `taxonomy` : Taxonomy slug. The slug you configured for your Custom Taxonomy.
+* `endpoint` : REST API endpoint from which this taxonomy can be fetched.
+* `postTypeEndpoint` \(optional\): REST API endpoint from which posts of this taxonomy can be fetched. Defaults to "posts", but **please note** that if the Custom Taxonomy is meant to load Custom Post Types instead, you have to add its endpoint here. To clarify, although optional for posts in the case of a Custom Post Type this argument is **required**.
+* `params` \(optional\): Extra params to be used while fetching the list of posts.
 
 Again, differentiating `taxonomy` and `endpoint`may be confusing as they usually are the same too. You can confirm you are doing it correctly by going to the Custom Taxonomy `endpoint` :
 
@@ -253,9 +253,9 @@ export default connect(CategoryNature);
 {% hint style="info" %}
 If you want to know more about how to use the `wp-source` package, here you have some videos where Frontity DevRel team talks about it:
 
-- 📺 [Frontity Talks 2020-01 - wp-source & CSS In JS \[1:36\]](https://www.youtube.com/watch?v=e-_66W8pfdY&t=96s)
-- 📺 [Frontity Talks 2020-02 - Pagination example & wp-source \(state & fetch\) \[17:53\]](https://www.youtube.com/watch?v=eW5xZlpcqQk&t=1073s)
-  {% endhint %}
+* 📺 [Frontity Talks 2020-01 - wp-source & CSS In JS \[1:36\]](https://www.youtube.com/watch?v=e-_66W8pfdY&t=96s)
+* 📺 [Frontity Talks 2020-02 - Pagination example & wp-source \(state & fetch\) \[17:53\]](https://www.youtube.com/watch?v=eW5xZlpcqQk&t=1073s)
+{% endhint %}
 
 ## API Reference
 
@@ -276,13 +276,13 @@ This action fetches all entities related to a `link`, i.e. the pathname of a URL
 {% hint style="info" %}
 `(link: string, options: object) => Promise`
 
-- **Parameters**
-  - **`link`**: string\` Link representing a REST API endpoint or custom handler
-  - _`options`_: `object` _\(optional\)_
-    - _`force`_: `boolean` The entities should be fetched again.
-- **Return value**
-  - `Promise` it doesn't return data but a promise that is resolved when the action is finished \(and state is updated\)
-    {% endhint %}
+* **Parameters**
+  * **`link`**: string\` Link representing a REST API endpoint or custom handler
+  * _`options`_: `object` _\(optional\)_
+    * _`force`_: `boolean` The entities should be fetched again.
+* **Return value**
+  * `Promise` it doesn't return data but a promise that is resolved when the action is finished \(and state is updated\)
+{% endhint %}
 
 All received data are populated in `state.source` and are accessible using the methods explained in the next section.
 
@@ -307,8 +307,8 @@ const somePost = state.source.get("/some-post"); // <- The data will exist.
 
 In React components, you won't need to use `async/await` with `fetch` because:
 
-- [`useEffect` doesn't directly accept `async` functions](https://reactjs.org/docs/hooks-reference.html#useeffect) although [it can contain `async`](https://www.robinwieruch.de/react-hooks-fetch-data) functions
-- They re-render when the `state` accessed changes.
+* [`useEffect` doesn't directly accept `async` functions](https://reactjs.org/docs/hooks-reference.html#useeffect) although [it can contain `async`](https://www.robinwieruch.de/react-hooks-fetch-data) functions
+* They re-render when the `state` accessed changes.
 
 ```javascript
 const SomePost = ({ actions, state }) => {
@@ -341,11 +341,11 @@ Returns an object that gives you info about the type of that link and related en
 {% hint style="info" %}
 `(link: string) => object`
 
-- **Parameters**
-  - **`link`**: `string` Link that points to a page in the Frontity site.
-- **Return value**
-  - `object` Info about the type of data represented in the link.
-    {% endhint %}
+* **Parameters**
+  * **`link`**: `string` Link that points to a page in the Frontity site.
+* **Return value**
+  * `object` Info about the type of data represented in the link.
+{% endhint %}
 
 For example:
 
@@ -391,22 +391,22 @@ will return something like
 
 The information to distinguish each type of link is based on the [WP Template Hierarchy](https://wphierarchy.com/) and is as follows:
 
-- archives: `isArchive`
-  - taxonomy: `isTaxonomy`
-    - category: `isCategory`
-    - tag: `isTag`
-    - deal: `isDeal`
-  - author: `isAuthor`
-  - postTypeArchive: `isPostTypeArchive`
-    - post: `isHome`, `isPostArchive` \(`isFrontPage` optional\)
-    - product: `isProductArchive`
-  - date: `isDate`
-- postTypes: `isPostType`
-  - post: `isPost`
-  - page: `isPage` \(`isFrontPage` optional\)
-  - product: `isProduct`
-  - media: `isMedia`, `isAttachment`
-- 404: `is404`
+* archives: `isArchive`
+  * taxonomy: `isTaxonomy`
+    * category: `isCategory`
+    * tag: `isTag`
+    * deal: `isDeal`
+  * author: `isAuthor`
+  * postTypeArchive: `isPostTypeArchive`
+    * post: `isHome`, `isPostArchive` \(`isFrontPage` optional\)
+    * product: `isProductArchive`
+  * date: `isDate`
+* postTypes: `isPostType`
+  * post: `isPost`
+  * page: `isPage` \(`isFrontPage` optional\)
+  * product: `isProduct`
+  * media: `isMedia`, `isAttachment`
+* 404: `is404`
 
 Additionally, if calling `get()` has returned a status code higher than `400`, we add information about the error to the state. For example, if an error code was `500`, the state will include the following properties:
 
@@ -425,11 +425,11 @@ Additionally, if calling `get()` has returned a status code higher than `400`, w
 
 Properties added to each type are also based on the [WP REST API](https://developer.wordpress.org/rest-api/reference/):
 
-- taxonomy: `taxonomy`, `id`
-- author: `id`
-- postTypeArchive: `type`
-- date: `year`, `month`, `date`
-- postType: `type`, `id`
+* taxonomy: `taxonomy`, `id`
+* author: `id`
+* postTypeArchive: `type`
+* date: `year`, `month`, `date`
+* postType: `type`, `id`
 
 #### `state.source[taxonomy][id]`
 
@@ -472,11 +472,11 @@ Set the URL to the WordPress REST API.
 {% hint style="info" %}
 `(link: string, options: object) => Promise`
 
-- **Parameters**
-  - `options: object`
-    _ **`api`**: `string` URL pointing to a valid WP REST API.
-    _ **`isWpCom`**: `boolean` if the WP REST route is from a WordPress.com hosted site.
-    {% endhint %}
+* **Parameters**
+  * `options: object`
+    * **`api`**: `string` URL pointing to a valid WP REST API.
+    * **`isWpCom`**: `boolean` if the WP REST route is from a WordPress.com hosted site.
+{% endhint %}
 
 **Example**
 
@@ -503,15 +503,15 @@ Request entity from the WordPress REST API.
 {% hint style="info" %}
 `(options: object) => Promise`
 
-- **Parameters**
-  - `options: object`
-    - **`endpoint`**: `string` Name of the endpoint if is a `/wp/v2` endpoint \(e.g. `posts`\), or the full path of other REST endpoints \(e.g. `/acf/v3/posts`\).
-    - **`params`**: `string` Any parameter that will be included in the query params.
-    - _`api`_: `string` _\(optional\)_ Overrides the value set with `api.set.`
-    - _`isWpCom`_: `boolean` _\(optional\)_ Overrides the value set with `api.set.`
-- **Return value**
-  - `Promise` Promise resolving to a [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) object from the fetch.
-    {% endhint %}
+* **Parameters**
+  * `options: object`
+    * **`endpoint`**: `string` Name of the endpoint if is a `/wp/v2` endpoint \(e.g. `posts`\), or the full path of other REST endpoints \(e.g. `/acf/v3/posts`\).
+    * **`params`**: `string` Any parameter that will be included in the query params.
+    * _`api`_: `string` _\(optional\)_ Overrides the value set with `api.set.`
+    * _`isWpCom`_: `boolean` _\(optional\)_ Overrides the value set with `api.set.`
+* **Return value**
+  * `Promise` Promise resolving to a [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) object from the fetch.
+{% endhint %}
 
 For more info, visit the [WP REST API reference](https://developer.wordpress.org/rest-api/reference).
 
@@ -546,27 +546,27 @@ Add entities to the Frontity state.
 {% hint style="info" %}
 `(options: object) => Promise`
 
-- **Parameters**
-  - `options: object`
-    - **`response`**: `object` The response object returned by `api.get().`
-    - **`state`**: `object` The state object from the Frontity store.
-    - _`subdirectory`_: `string` _\(optional\)_ Domain's subdirectory where your Frontity site is accessible. When this options is passed, this subdirectory is added to the entities' links. By default, it takes the value defined in `state.source.subdirectory`.
-    - _`force`_: `boolean` _\(optional\)_ Value indicating if the entities should be overwritten.`false` by default.
-- **Return value**
-  - `Array` An array of objects with attributes `type`, `id` and `link` representing the added entities.
-    {% endhint %}
+* **Parameters**
+  * `options: object`
+    * **`response`**: `object` The response object returned by `api.get().`
+    * **`state`**: `object` The state object from the Frontity store.
+    * _`subdirectory`_: `string` _\(optional\)_ Domain's subdirectory where your Frontity site is accessible. When this options is passed, this subdirectory is added to the entities' links. By default, it takes the value defined in `state.source.subdirectory`.
+    * _`force`_: `boolean` _\(optional\)_ Value indicating if the entities should be overwritten.`false` by default.
+* **Return value**
+  * `Array` An array of objects with attributes `type`, `id` and `link` representing the added entities.
+{% endhint %}
 
 Entities are normally never overwritten. So, if an entity already exists in the state and a new one is fetched, the one in the state will prevail. If you want to overwrite them, `populate` should be called with `force: true`.
 
 **Example**
 
 ```javascript
-const response = await libraries.source.api.get({ endpoint: "posts" });
-const entitiesAdded = await libraries.source.populate({ response, state });
+const response = await libraries.source.api.get({ endpoint: "posts" })
+const entitiesAdded = await libraries.source.populate({ response, state })
 
-entitiesAdded.forEach(({ type, id, link }) => {
-  console.log({ type, id, link });
-});
+entitiesAdded.forEach(({type, id, link}) => {
+  console.log({type, id, link})
+})
 ```
 
 #### `libraries.source.handlers`
@@ -576,19 +576,20 @@ Handlers are objects that associate a path pattern with a function that gets the
 {% hint style="info" %}
 A handler is defined by an object with the following properties:
 
-- **`name`**: `string` Identifier of the handler.
-- **`priority`**: `number` Number that lets `fetch` to know in which order handlers should be evaluated.
-- **`pattern`**: `regExp` Pattern which paths are compared with. We use [path-to-regexp](https://github.com/pillarjs/path-to-regexp) under the hood, so check its documentation to know how to write patterns.
-- **`func`**: `function` Asynchronous function that retrieves entities and adds all info to the state.
-  - Arguments
-    - `options: object`
-      - **`link`**: `string` The link that are being fetched.
-      - **`params`**: values obtained from the pattern after a match
-      - **`state`**: `object` Frontity state.
-      - **`libraries`**: `object` Frontity libraries.
-      - **`force`**: `boolean` If the entities should be fetched again. Internally, this parameter will be passed to the `actions.source.fetch` call.
-  - Return value \* `Promise` Promise resolving to custom data
-    {% endhint %}
+* **`name`**: `string` Identifier of the handler.
+* **`priority`**: `number` Number that lets `fetch` to know in which order handlers should be evaluated.
+* **`pattern`**: `regExp` Pattern which paths are compared with. We use [path-to-regexp](https://github.com/pillarjs/path-to-regexp) under the hood, so check its documentation to know how to write patterns.
+* **`func`**: `function` Asynchronous function that retrieves entities and adds all info to the state.
+  * Arguments
+    * `options: object`
+      * **`link`**: `string` The link that are being fetched.
+      * **`params`**: values obtained from the pattern after a match
+      * **`state`**: `object` Frontity state.
+      * **`libraries`**: `object` Frontity libraries.
+      * **`force`**: `boolean` If the entities should be fetched again. Internally, this parameter will be passed to the `actions.source.fetch` call.
+  * Return value
+    * `Promise` Promise resolving to custom data
+{% endhint %}
 
 `libraries.source.handlers` is an array., so **to add new handlers we can use `libraries.source.handlers.push()`**
 
@@ -632,16 +633,16 @@ Redirections are objects that associate a path pattern with a function that retu
 {% hint style="info" %}
 A redirection is defined by an object with the following properties:
 
-- **`name`**: `string` Identifier of the redirection.
-- **`priority`**: `number` Let `fetch` to know in which order redirections should be evaluated.
-- **`pattern`**: `regExp` Pattern which paths are compared with.
-- **`func`**: Function that returns a new path. It receives an object with the params obtained after a match.
-  - Arguments
-    _ `options: object`
-    _ **`slug`**: `string` The link that is being fetched.
-    _ Return value
-    _ `string` a new path
-    {% endhint %}
+* **`name`**: `string` Identifier of the redirection.
+* **`priority`**: `number` Let `fetch` to know in which order redirections should be evaluated.
+* **`pattern`**: `regExp` Pattern which paths are compared with.
+* **`func`**: Function that returns a new path. It receives an object with the params obtained after a match.
+  * Arguments
+    * `options: object`
+      * **`slug`**: `string` The link that is being fetched.
+    * Return value
+      * `string` a new path
+{% endhint %}
 
 **Example**
 
@@ -662,15 +663,15 @@ Utility for parsing links.
 {% hint style="info" %}
 `(link: string) => object`
 
-- **Parameters**
-  - `link`: any link that points to entities in your site \(links, custom lists, etc.\)
-- **Return value**
-  - `object`
-    _ **`path`**: `string` Pathname without the page
-    _ **`page`**: `number` The page number
-    _ **`query`**: `object` Object with query parameters
-    _ **`hash`**: `string` The hash value \(with `#`\).
-    {% endhint %}
+* **Parameters**
+  * `link`: any link that points to entities in your site \(links, custom lists, etc.\)
+* **Return value**
+  * `object`
+    * **`path`**: `string` Pathname without the page
+    * **`page`**: `number` The page number
+    * **`query`**: `object` Object with query parameters
+    * **`hash`**: `string` The hash value \(with `#`\).
+{% endhint %}
 
 #### `libraries.source.stringify()`
 
@@ -679,26 +680,27 @@ Utility for building links from its attributes.
 {% hint style="info" %}
 `(args: object) => string`
 
-- **Parameters**
-  - **`path`**: `string` pathname without the page
-  - _`page`_: `number` _\(optional\)_ The page number
-  - _`query`_: `object` _\(optional\)_ Object with query parameters
-  - _`hash`_: `string` _\(optional\)_ The hash value \(with `#`\).
-- **Return value**
-  - `link`: `string` Normalized link
-    {% endhint %}
+* **Parameters**
+  * **`path`**: `string` pathname without the page
+  * _`page`_: `number` _\(optional\)_ The page number
+  * _`query`_: `object` _\(optional\)_ Object with query parameters
+  * _`hash`_: `string` _\(optional\)_ The hash value \(with `#`\).
+* **Return value**
+  * `link`: `string` Normalized link
+{% endhint %}
 
 #### `libraries.source.normalize()`
 
 {% hint style="info" %}
 `(link: string) => string`
 
-- **Parameters**
-  - `link`: `string` Any link that points to entities in your site \(links, custom lists, etc.\)
-- **Return value**
-  - `link`: `string` Normalized link
-    {% endhint %}
+* **Parameters**
+  * `link`: `string` Any link that points to entities in your site \(links, custom lists, etc.\)
+* **Return value**
+  * `link`: `string` Normalized link
+{% endhint %}
 
 {% hint style="info" %}
 Still have questions? Ask [the community](https://community.frontity.org/)! We are here to help 😊
 {% endhint %}
+


### PR DESCRIPTION
I saw that we are using the wrong description for the arguments of `state.source.get()` in the `wp-source` package, so I fixed it.

Feel free to change/improve it if you think it's convenient. :slightly_smiling_face:  