### PR TITLE
Remove space requirement in TSDocs

### DIFF
--- a/docs/contributing/code-contribution-guide.md
+++ b/docs/contributing/code-contribution-guide.md
@@ -352,45 +352,6 @@ const validateEmail = (email: string): ValidateEmailReturn => {
 };
 ```
 
-### 3. Add a line break between TSDoc comments
-
-Use
-
-```ts
-/**
- * Some interface.
- */
-interface Something {
-  /**
-   * A property of this interface.
-   */
-  prop1: string;
-
-  /**
-   * Another property of this interface.
-   */
-  prop2: string;
-}
-```
-
-Instead of
-
-```ts
-/**
- * Some interface.
- */
-interface Something {
-  /**
-   * A property of this interface.
-   */
-  prop1: string;
-  /**
-   * Another property of this interface.
-   */
-  prop2: string;
-}
-```
-
 ## Changelogs
 
 We use [Changesets](https://github.com/atlassian/changesets/) to manage our versioning and changelogs.


### PR DESCRIPTION
This is not required anymore because we automated it here: https://github.com/frontity/frontity/commit/518c19a7934faf64f7027190190405825aa31f7a.