### PR TITLE
Fix the npm-package name on the "tiny-router" reference page

### DIFF
--- a/docs/api-reference-1/router.md
+++ b/docs/api-reference-1/router.md
@@ -2,10 +2,10 @@
 
 ## Installation
 
-Add the `tiny-source` package to your project:
+Add the `tiny-router` package to your project:
 
 ```text
-npm i @frontity/tiny-source
+npm i @frontity/tiny-router
 ```
 
 And include it in your `frontity.settings.js` file:


### PR DESCRIPTION
I do similar mistakes when I don't sleep enough =)