### PR TITLE
Remove the unnecessary argument in "Core concepts - Roots"

### DIFF
--- a/docs/learning-frontity/roots.md
+++ b/docs/learning-frontity/roots.md
@@ -86,7 +86,7 @@ export default {
     },
     actions: {
         share: {
-            openModal: ({ state, actions }) => {
+            openModal: ({ state }) => {
                 state.share.isModalOpen = true;
             },
             closeModal: ({ state }) => {


### PR DESCRIPTION
`actions` isn't used in this example of code