### PR TITLE
Reviewed quick started guide

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -4,48 +4,25 @@
 
 Frontity is a **React-based framework** that enables you to easily build a frontend for a headless \(or decoupled\) WordPress site. Your WordPress site serves its data via the REST-API. Frontity framework is open source and free to use.
 
-## Table of Contents
-
-<!-- toc -->
-
-- [Requirements](#requirements)
-  * [WordPress](#wordpress)
-    + [Have a recent WordPress version](#have-a-recent-wordpress-version)
-    + [Set the right REST API URL](#set-the-right-rest-api-url)
-    + [Have pretty permalinks activated](#have-pretty-permalinks-activated)
-  * [Node.js](#node-js)
-    + [Have Node.js and npm installed](#have-node-js-and-npm-installed)
-- [Get up and running](#get-up-and-running)
-
-<!-- tocstop -->
-
 ## Requirements
 
 To get started with Frontity you will need:
 
-* **A WordPress installation** - This can be hosted locally, on a web-server, or you can also use a site hosted on wordpress.com
+### A WordPress installation
 
-* **Node.js** - If you don't already have it you can get *Node.js* from [the official site](https://nodejs.org/). This will also install `npm` and `npx` along with Node.js
+Frontity provides a [default WordPress site](https://test.frontity.org/) as source of data in every new project so for this Quick Start Guide we can work with this one
 
-  You will use these to run Frontity commands during the set-up and development of your project
+You can also [set your own WordPress installation](use-your-wordpress-installation.md). This can be hosted locally, on a web-server, or you can also use a site hosted on wordpress.com. 
+
+### Node.js
+
+If you don't already have it you can get *Node.js* from [the official site](https://nodejs.org/). This will also install `npm` and `npx` along with Node.js
+
+You will use these to run Frontity commands during the set-up and development of your project
 
 
 {% hint style="info" %}
 For those coming from WordPress it might be worth noting that *Frontity* runs on **Node.js**, so it needs to be deployed in a different server than your WordPress. If you want to learn more about this, visit our [GitHub repo](https://github.com/frontity/frontity#why-a-different-nodejs-server) or see the [Architecture](../architecture.md) section arch these docs.
-
-{% endhint %}
-
-### WordPress
-
-#### Have a recent WordPress version
-
-Frontity depends on the WordPress REST-API. If you have a recent version of WordPress installed, or if you're using wordpress.com then you should be good to go.
-
-To check that the WordPress REST-API is working you can type one of the following into your browser's address bar. You should get a lot of complicated looking stuff in your browser. Don't worry, this is JSON and Frontity is very happy with this.
-
-### Node.js
-
-#### Have Node.js and npm installed
 
 To test if you have Node.js installed open your terminal and run:
 
@@ -56,9 +33,6 @@ node -v
 ```text
 npm -v
 ```
-----
-
-Once you have a WordPress site and Node.js you're good to go and all set to get up and running....
 
 ## Get up and running
 

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -10,15 +10,15 @@ To get started with Frontity you will need:
 
 ### A WordPress installation
 
-Frontity provides a [default WordPress site](https://test.frontity.org/) as source of data in every new project so for this Quick Start Guide we can work with this one
+By default Frontity provides an [example WordPress site](https://test.frontity.org/) as the data source for every new project, so for this Quick Start Guide we will work with this.
 
-You can also [set your own WordPress installation](use-your-wordpress-installation.md). This can be hosted locally, on a web-server, or you can also use a site hosted on wordpress.com. 
+You can also [configure your own WordPress installation](quick-start-guide#set-your-own-wordpress-installation) to be the data source. This can be hosted either locally on your development machine, or on a web-server. You can also use a site hosted on wordpress.com.
 
 ### Node.js
 
-If you don't already have it you can get *Node.js* from [the official site](https://nodejs.org/). This will also install `npm` and `npx` along with Node.js
+If you don't already have it you can get *Node.js* from [the official site](https://nodejs.org/). This will also install `npm` and `npx` along with Node.js.
 
-You will use these to run Frontity commands during the set-up and development of your project
+You will use these to run Frontity commands during the set-up and development of your project.
 
 
 {% hint style="info" %}
@@ -26,11 +26,11 @@ For those coming from WordPress it might be worth noting that *Frontity* runs on
 
 To test if you have Node.js installed open your terminal and run:
 
-```text
+```bash
 node -v
 ```
 
-```text
+```bash
 npm -v
 ```
 

--- a/docs/getting-started/quick-start-guide.md
+++ b/docs/getting-started/quick-start-guide.md
@@ -44,7 +44,9 @@ A development server will be started. This server will be listening on http://lo
 
 Open the project directory in your preferred code editor/IDE and try editing some of the files under `packages/mars-theme`. Each time you save a change the browser will automatically reload and display the new version as these changes are detected by the development server.
 
-5 - **Set your own WordPress installation** as data source
+## Set your own WordPress installation
+
+A good next step is **setting your own WordPress installation** as the data source
 
 You can connect your [_own WordPress site_](https://docs.frontity.org/guides/what-are-the-requisites-of-wordpress-for-frontity) to your Frontity project by [setting the `state.source.url`](https://docs.frontity.org/guides/setting-url-wordpress-source-data) property in the `frontity.settings.js` file.
 
@@ -69,7 +71,7 @@ const settings = {
 By default, `state.source.url` is set to `https://test.frontity.org/` (our demo WordPress site) but you can set this property to any valid URL pointing to a WordPress site.
 
 {% hint style="info" %}
-Setting `state.source.url` will be enough for most WordPress installations and plans. For specific use cases check the guide [*Setting the URL of the WordPress data source*](https://docs.frontity.org/guides/setting-url-wordpress-source-data)
+Setting `state.source.url` should be sufficient for most WordPress.org installations and WordPress.com plans. For specific use cases check the guide [*Setting the URL of the WordPress data source*](https://docs.frontity.org/guides/setting-url-wordpress-source-data).
 {% endhint %}
 
 > Your site at `http://localhost:3000` won't auto-update with this change as auto-updates only occur with changes to files in the packages directory, so you will need to manually refresh the page in your browser.

--- a/docs/getting-started/quick-start-guide.md
+++ b/docs/getting-started/quick-start-guide.md
@@ -46,7 +46,7 @@ Open the project directory in your preferred code editor/IDE and try editing som
 
 5 - **Set your own WordPress installation** as data source
 
-You can connect your [own WordPress site](https://docs.frontity.org/guides/what-are-the-requisites-of-wordpress-for-frontity) to your Frontity project by setting the `state.source.url` property in the `frontity.settings.js` file.
+You can connect your [_own WordPress site_](https://docs.frontity.org/guides/what-are-the-requisites-of-wordpress-for-frontity) to your Frontity project by setting the `state.source.url` property in the `frontity.settings.js` file.
 
 ```javascript
 const settings = {
@@ -69,7 +69,7 @@ const settings = {
 By default, `state.source.url` is set to `https://test.frontity.org/` (our demo WordPress site) but you can set this property to any valid URL pointing to a WordPress site.
 
 {% hint style="info" %}
-Setting `state.source.url` will be enough for most WordPress installations and plans. For specific use cases check the guide [**Setting the URL of the WordPress data source**](https://docs.frontity.org/guides/setting-url-wordpress-source-data)
+Setting `state.source.url` will be enough for most WordPress installations and plans. For specific use cases check the guide [*Setting the URL of the WordPress data source*](https://docs.frontity.org/guides/setting-url-wordpress-source-data)
 {% endhint %}
 
 

--- a/docs/getting-started/quick-start-guide.md
+++ b/docs/getting-started/quick-start-guide.md
@@ -44,9 +44,9 @@ A development server will be started. This server will be listening on http://lo
 
 Open the project directory in your preferred code editor/IDE and try editing some of the files under `packages/mars-theme`. Each time you save a change the browser will automatically reload and display the new version as these changes are detected by the development server.
 
-5 - **Set your own WordPress installation** as the source of data
+5 - **Set your own WordPress installation** as data source
 
-You can connect your own WordPress site to your Frontity project by setting the `state.source.url` property in the `frontity.settings.js` file.
+You can connect your [own WordPress site](https://docs.frontity.org/guides/what-are-the-requisites-of-wordpress-for-frontity) to your Frontity project by setting the `state.source.url` property in the `frontity.settings.js` file.
 
 ```javascript
 const settings = {
@@ -66,21 +66,18 @@ const settings = {
 }
 ```
 
-{% hint style="info" %}
-Check the guide [**Setting the URL of the WordPress data source**](https://docs.frontity.org/guides/setting-url-wordpress-source-data) to learn more about how to properly set the URL of the WordPress data source taking into account the different WordPress scenarios
-{% endhint %}
-
 By default, `state.source.url` is set to `https://test.frontity.org/` (our demo WordPress site) but you can set this property to any valid URL pointing to a WordPress site.
 
-Your site at `http://localhost:3000` won't auto-update with this change as auto-updates only occur with changes to files in the packages directory, so you will need to manually refresh the page in your browser.
+{% hint style="info" %}
+Setting `state.source.url` will be enough for most WordPress installations and plans. 
+
+For specific use cases check the guide [**Setting the URL of the WordPress data source**](https://docs.frontity.org/guides/setting-url-wordpress-source-data) to learn more about how to properly set the URL of the WordPress data source taking into account the different WordPress scenarios
+{% endhint %}
+
+
+> Your site at `http://localhost:3000` won't auto-update with this change as auto-updates only occur with changes to files in the packages directory, so you will need to manually refresh the page in your browser.
 
 You should now see your own posts in the Frontity project displayed in the browser.
-
-{% hint style="info" %}
-If you use your own WordPress installation take into account you need to use one of the pretty permalinks options, rather than the plain one, in `Settings->Permalinks`.
-
-![](../.gitbook/assets/wordpress-permalink-setting.png)
-{% endhint %}
 
 ## What's next?
 

--- a/docs/getting-started/quick-start-guide.md
+++ b/docs/getting-started/quick-start-guide.md
@@ -46,7 +46,7 @@ Open the project directory in your preferred code editor/IDE and try editing som
 
 5 - **Set your own WordPress installation** as data source
 
-You can connect your [_own WordPress site_](https://docs.frontity.org/guides/what-are-the-requisites-of-wordpress-for-frontity) to your Frontity project by setting the `state.source.url` property in the `frontity.settings.js` file.
+You can connect your [_own WordPress site_](https://docs.frontity.org/guides/what-are-the-requisites-of-wordpress-for-frontity) to your Frontity project by [setting the `state.source.url`](https://docs.frontity.org/guides/setting-url-wordpress-source-data) property in the `frontity.settings.js` file.
 
 ```javascript
 const settings = {
@@ -71,7 +71,6 @@ By default, `state.source.url` is set to `https://test.frontity.org/` (our demo 
 {% hint style="info" %}
 Setting `state.source.url` will be enough for most WordPress installations and plans. For specific use cases check the guide [*Setting the URL of the WordPress data source*](https://docs.frontity.org/guides/setting-url-wordpress-source-data)
 {% endhint %}
-
 
 > Your site at `http://localhost:3000` won't auto-update with this change as auto-updates only occur with changes to files in the packages directory, so you will need to manually refresh the page in your browser.
 

--- a/docs/getting-started/quick-start-guide.md
+++ b/docs/getting-started/quick-start-guide.md
@@ -69,9 +69,7 @@ const settings = {
 By default, `state.source.url` is set to `https://test.frontity.org/` (our demo WordPress site) but you can set this property to any valid URL pointing to a WordPress site.
 
 {% hint style="info" %}
-Setting `state.source.url` will be enough for most WordPress installations and plans. 
-
-For specific use cases check the guide [**Setting the URL of the WordPress data source**](https://docs.frontity.org/guides/setting-url-wordpress-source-data) to learn more about how to properly set the URL of the WordPress data source taking into account the different WordPress scenarios
+Setting `state.source.url` will be enough for most WordPress installations and plans. For specific use cases check the guide [**Setting the URL of the WordPress data source**](https://docs.frontity.org/guides/setting-url-wordpress-source-data)
 {% endhint %}
 
 


### PR DESCRIPTION
Reviewed quick started guide to remove friction before starting and by extracting "noise" into external guides:

- [Setting the URL of the WordPress data source](https://docs.frontity.org/guides/setting-url-wordpress-source-data)
- [WordPress requirements for Frontity](https://docs.frontity.org/guides/what-are-the-requisites-of-wordpress-for-frontity)
