### PR TITLE
Suggest updating only to minor versions

### DIFF
--- a/docs/guides/keep-frontity-updated.md
+++ b/docs/guides/keep-frontity-updated.md
@@ -14,7 +14,7 @@ npm install
 ```
 
 {% hint style="info" %}
-Note that using the `-t minor` switch ensures that only minor updates will be applied. This avoids introducing potential breaking changes that a major update might introduce.
+Note that using the `-t minor` switch ensures that only minor updates will be applied. This avoids introducing potential breaking changes that a major update might introduce. [See here](https://github.com/raineorshine/npm-check-updates) for more info.
 {% endhint %}
 
 With this, **you will update your `package.json` and all your dependencies in `node_modules`**, including the Frontity packages installed in **`node_modules`**.

--- a/docs/guides/keep-frontity-updated.md
+++ b/docs/guides/keep-frontity-updated.md
@@ -13,7 +13,11 @@ npx npm-check-updates -u -t minor
 npm install
 ```
 
-With this, **you will update your `package.json` and all your dependencies in `node_modules`**, including the Frontity packages installed in **`node_modules`**. 
+{% hint style="info" %}
+Note that using the `-t minor` switch ensures that only minor updates will be applied. This avoids introducing potential breaking changes that a major update might introduce.
+{% endhint %}
+
+With this, **you will update your `package.json` and all your dependencies in `node_modules`**, including the Frontity packages installed in **`node_modules`**.
 
 If you want to update just one package you can do it with this other command:
 

--- a/docs/guides/keep-frontity-updated.md
+++ b/docs/guides/keep-frontity-updated.md
@@ -9,7 +9,7 @@ At this point, it is important to distinguish between your **dependencies** \(np
 Essential packages such as `frontity`, `@frontity/core` or `@frontity/tiny-router`, and all your dependencies, are included in this part. These can be treated as common npm packages, so you can use the following command to update your `package.json` to the latest versions:
 
 ```bash
-npx npm-check-updates -u
+npx npm-check-updates -u -t minor
 npm install
 ```
 
@@ -29,7 +29,7 @@ To update the dependencies of your local package dependencies, go to their folde
 
 ```bash
 cd package/my-local-package
-npx npm-check-updates -u
+npx npm-check-updates -u -t minor
 # DO NOT RUN "npm install" this time!
 ```
 


### PR DESCRIPTION
By default `npx npm-check-updates -u` does major updates of the packages, which means that an application could break so it is safer to recommend the `-t minor` option to restrict updates to only minor updates.