### PR TITLE
Update documentation based on rebranding by Moovweb

### DIFF
--- a/docs/deployment/deploy-on-moovweb-xdn.md
+++ b/docs/deployment/deploy-on-moovweb-xdn.md
@@ -1,17 +1,17 @@
-# Deploy Frontity on Moovweb XDN
+# Deploy Frontity on Layer0
 
-The [Moovweb XDN](https://developer.moovweb.com/) is an all-in-one platform to develop, deploy, preview, experiment on, monitor, and run your headless frontend. The XDN is focused on large, dynamic websites and performance through an integrated Content Delivery Network \(CDN\), CDN-as-JavaScript, predictive prefetching, and performance monitoring. Moovweb offers a free tier.
+[Layer0](https://layer0.co) is an all-in-one platform to develop, deploy, preview, experiment on, monitor, and run your headless frontend. It is focused on large, dynamic websites and best-in-class performance through EdgeJS (a JavaScript-based Content Delivery Network), predictive prefetching, and performance monitoring.
 
-Moovweb XDN's CDN-as-JavaScript enables powerful and precise control of Edge based [caching](https://developer.moovweb.com/guides/caching) and [routing](https://developer.moovweb.com/guides/routing) that can improve the performance for Frontity sites.
+Layer0's EdgeJS enables powerful and precise control of Edge based [caching](https://developer.layer0.co/guides/caching) and [routing](https://developer.layer0.co/guides/routing) that can improve the performance for Frontity sites.
 
-For the full details on deploying Frontity to the XDN, refer to the [Frontity on Moovweb XDN guide](https://developer.moovweb.com/guides/frontity) in the developer documentation.
+For the full details on deploying Frontity on Layer0 refer to the [Frontity on Layer0 guide](https://developer.layer0.co/guides/frontity) in the developer documentation.
 
 ## Getting Started
 
-First start by installing the [XDN command line interface \(CLI\)](https://developer.moovweb.com/guides/cli),
+First start by installing the [Layer0 command line interface \(CLI\)](https://developer.layer0.co/guides/cli),
 
 ```bash
-npm i -g @xdn/cli
+npm i -g @layer0/cli
 ```
 
 ## Project setup
@@ -20,44 +20,44 @@ Run the `init` command in the directory of your Frontity project:
 
 ```bash
 cd my-frontity-app
-xdn init
+layer0 init
 ```
 
-This will automatically configure your app for deployment on the XDN.
+This will automatically configure your app for deployment on Layer0.
 
 ## Running locally
 
-You can simulate your app running on the XDN using the `dev` command:
+You can simulate your app running on Layer0 using the `dev` command:
 
 ```bash
-xdn dev
+layer0 dev
 ```
 
 In particular, the `--cache` option will emulate Edge caching rules locally so that you can test easily test edge behavior during development without having to do a deploy to the cloud:
 
 ```bash
-xdn dev --cache
+layer0 dev --cache
 ```
 
 ## Deploying
 
-Deploying a Frontity app requires an account on the Moovweb XDN. [Sign up here for free](https://moovweb.app/signup).
+Deploying a Frontity app requires an account on Layer0. [Sign up here for free](https://app.layer0.co/signup).
 
 Once you have installed the CLI and created an account, you should login from the terminal by running the `login` command:
 
 ```bash
-xdn login
+layer0 login
 ```
 
-Once you have an account and have logged in to the CLI, you can deploy to the Moovweb XDN by running the following in the root folder of your project:
+Once you have an account and have logged in to the CLI, you can deploy to the Layer0 by running the following in the root folder of your project:
 
 ```text
-xdn deploy
+layer0 deploy
 ```
 
 ## Enabling Prefetching \(optional\)
 
-The XDN improves the performance of your site by bundling an integrated server worker that will predictively prefetch cached pages from the edge. To add the XDN service worker to your app, call the `install` function from `@xdn/prefetch/window` in a `useEffect` hook when the app first loads. For example, you can alter the Header component in your theme as follows:
+Layer0 improves the performance of your site by bundling an integrated server worker that will predictively prefetch cached pages from the edge. To add the Layer0 service worker to your app, call the `install` function from `@layer0/prefetch/window` in a `useEffect` hook when the app first loads. For example, you can alter the Header component in your theme as follows:
 
 ```javascript
 // mars-theme/src/components/header.js
@@ -75,10 +75,10 @@ const Header = ({ state }) => {
 }
 ```
 
-To prefetch data into the browser cache using the service worker, use the Prefetch component from @xdn/react. This component prefetches a specific url from the XDN edge when it becomes visible in the viewport. You typically wrap it around links. For example:
+To prefetch data into the browser cache using the service worker, use the Prefetch component from @layer0/react. This component prefetches a specific url from the Layer0 edge when it becomes visible in the viewport. You typically wrap it around links. For example:
 
 ```javascript
-import { Prefetch } from '@xdn/react'
+import { Prefetch } from '@layer0/react'
 
 function MyComponent() {
   return (

--- a/docs/deployment/deploy-on-moovweb-xdn.md
+++ b/docs/deployment/deploy-on-moovweb-xdn.md
@@ -2,13 +2,13 @@
 
 [Layer0](https://layer0.co) is an all-in-one platform to develop, deploy, preview, experiment on, monitor, and run your headless frontend. It is focused on large, dynamic websites and best-in-class performance through EdgeJS (a JavaScript-based Content Delivery Network), predictive prefetching, and performance monitoring.
 
-Layer0's EdgeJS enables powerful and precise control of Edge based [caching](https://developer.layer0.co/guides/caching) and [routing](https://developer.layer0.co/guides/routing) that can improve the performance for Frontity sites.
+Layer0's EdgeJS enables powerful and precise control of Edge based [caching](https://docs.layer0.co/guides/caching) and [routing](https://docs.layer0.co/guides/routing) that can improve the performance for Frontity sites.
 
-For the full details on deploying Frontity on Layer0 refer to the [Frontity on Layer0 guide](https://developer.layer0.co/guides/frontity) in the developer documentation.
+For the full details on deploying Frontity on Layer0 refer to the [Frontity on Layer0 guide](https://docs.layer0.co/guides/frontity) in the developer documentation.
 
 ## Getting Started
 
-First start by installing the [Layer0 command line interface \(CLI\)](https://developer.layer0.co/guides/cli),
+First start by installing the [Layer0 command line interface \(CLI\)](https://docs.layer0.co/guides/cli),
 
 ```bash
 npm i -g @layer0/cli


### PR DESCRIPTION
Moovweb was rebranded to Layer0 some few weeks ago (https://www.layer0.co/post/introducing-layer0).