### PR TITLE
Add info about revisions

### DIFF
--- a/docs/architecture/embedded-mode.md
+++ b/docs/architecture/embedded-mode.md
@@ -85,7 +85,7 @@ In this mode content editors continue to have the same editing experience:
 - Post previews work just the same as in a normal (non-headless) WordPress installation.
 
 {% hint style="warning" %}
-In order to access post previews from the REST API, revisions need to be activated for all your custom post types. You can read more about revisions on the [official WordPress docs](https://wordpress.org/support/article/revisions/).
+In order to access post previews from the REST API revisions need to be activated. You can read more about revisions on the [official WordPress docs](https://wordpress.org/support/article/revisions/). And if you are using custom post types, remember to [add support for revisions](https://developer.wordpress.org/reference/functions/register_post_type/#supports) when you register them.
 {% endhint %}
 
 ## Caching in Embedded Mode

--- a/docs/architecture/embedded-mode.md
+++ b/docs/architecture/embedded-mode.md
@@ -84,6 +84,9 @@ In this mode content editors continue to have the same editing experience:
 - The admin bar is visible for logged in users.
 - Post previews work just the same as in a normal (non-headless) WordPress installation.
 
+{% hint style="warning" %}
+In order to access post previews from the REST API, revisions need to be activated for all your custom post types. You can read more about revisions on the [official WordPress docs](https://wordpress.org/support/article/revisions/).
+{% endhint %}
 
 ## Caching in Embedded Mode
 


### PR DESCRIPTION
This PR instructs users that revisions need to be activated in order to retrieve the latest preview content from the REST API.